### PR TITLE
fixed preview background color

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -36,9 +36,8 @@ h4 {
 
 .gmail_signature{
   padding: 2rem;
-  font-size: 90%;
   white-space: nowrap;
-  background: #F1F1F1;
+  background: transparent;
   border: 1px solid #E1E1E1;
   border-radius: 4px;
 }


### PR DESCRIPTION
removed background on preview to prevent the signature to get the grey background when copied and pasted 