### PR TITLE
removed transparent background color

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -37,7 +37,6 @@ h4 {
 .gmail_signature{
   padding: 2rem;
   white-space: nowrap;
-  background: transparent;
   border: 1px solid #E1E1E1;
   border-radius: 4px;
 }


### PR DESCRIPTION
I removed transparent background color on signature preview that may cause some issues on new Apple Mail dark interface when copied and pasted.